### PR TITLE
Fix typo and improve formatting

### DIFF
--- a/_posts/2020-09-06-hello-world.markdown
+++ b/_posts/2020-09-06-hello-world.markdown
@@ -5,21 +5,21 @@ date:   2020-09-06 12:23:31 +0200
 categories: jekyll update
 ---
 
-Writing my first post using GitHub static pages and Jekyll accomplish! &#9989;
+Writing my first post using GitHub static pages and Jekyll accomplished! &#9989;
 
 In case you are also interested in doing the same here are the resources I have used:
 
-1. Installing [Jekyll](https://jekyllrb.com/docs/installation/macos/) . 
+1. Installing [Jekyll](https://jekyllrb.com/docs/installation/macos/). 
+  
+   This tutorial assumes you are using a *bash* shell. 
+   If your shell is *zsh* instead, use the command below to enable Jekyll commands in your terminal:
 
-This tutorial assumes you are using a *bash* shell. 
-If your shell is *zsh* instead, use the command below to enable Jekyll commands in your terminal:
+   ```
+   echo 'export PATH="$HOME/.gem/ruby/2.6.0/bin:$PATH"' >> ~/.zshrc
+   ```
 
-```
-echo 'export PATH="$HOME/.gem/ruby/2.6.0/bin:$PATH"' >> ~/.zshrc
-```
-
-2. Instructions on how to [create/use](https://docs.github.com/en/github/working-with-github-pages/creating-a-github-pages-site-with-jekyll) 
-GitHub pages with Jekyll. 
+1. Instructions on how to [create/use](https://docs.github.com/en/github/working-with-github-pages/creating-a-github-pages-site-with-jekyll) 
+   GitHub pages with Jekyll. 
 
 That is all for the first post.
 


### PR DESCRIPTION
For numbered lists in github's markdown you use always `1.` and markdown tracks the number of bullet